### PR TITLE
Fix non-ASCII font glyphs dropped during asset build on Windows (Fixes #18)

### DIFF
--- a/assets/build.gradle.kts
+++ b/assets/build.gradle.kts
@@ -149,6 +149,14 @@ val convertPixelPerfect = convertBatch("convertPixelPerfect", "textures/pixelper
 val fontInfoDir = layout.buildDirectory.dir("resources/font")
 val fontTexClasspath = "/textures/font"
 
+// Extra glyphs to bake into the font atlases beyond the base codepoint range.
+// Passed to FontRenderer as ASCII hex codepoints rather than literal characters: command-line
+// arguments are encoded through the JVM's sun.jnu.encoding, which is the legacy ANSI code page on
+// Windows (e.g. Cp1252) and silently replaces non-Latin-1 glyphs like ∞ ← ⌘ with '?'. Hex is ASCII
+// and survives the argv boundary identically on every platform.
+val extraGlyphs = "…–—•°™∞␡␈c←↑→↓⌃⇧⌥⌘□"
+val extraGlyphCodepoints = extraGlyphs.codePoints().toArray().joinToString(",") { Integer.toHexString(it) }
+
 val renderInterLightFont = tasks.register<JavaExec>("renderInterLightFont") {
     group = "build"
     description = "Renders Inter Light TTF font to PNG texture and font metadata."
@@ -160,12 +168,13 @@ val renderInterLightFont = tasks.register<JavaExec>("renderInterLightFont") {
     val outDir = layout.buildDirectory.dir("font_png/light")
     
     inputs.file(ttfFile)
+    inputs.property("glyphs", extraGlyphs)
     outputs.files(
         fontInfoDir.get().file("inter-light_13.font"),
         outDir.get().file("inter-light_13.png")
     )
-    
-    args = listOf(ttfFile.absolutePath, "13", "2048", "1200", "2", fontInfoDir.get().asFile.absolutePath, outDir.get().asFile.absolutePath, fontTexClasspath, "…–—•°™∞␡␈c←↑→↓⌃⇧⌥⌘□")
+
+    args = listOf(ttfFile.absolutePath, "13", "2048", "1200", "2", fontInfoDir.get().asFile.absolutePath, outDir.get().asFile.absolutePath, fontTexClasspath, extraGlyphCodepoints)
     onlyIf { ttfFile.exists() }
 }
 
@@ -184,12 +193,13 @@ val renderInterTightBlackFont = tasks.register<JavaExec>("renderInterTightBlackF
     val outDir = layout.buildDirectory.dir("font_png/black")
     
     inputs.file(ttfFile)
+    inputs.property("glyphs", extraGlyphs)
     outputs.files(
         fontInfoDir.get().file("intertight-black_28.font"),
         outDir.get().file("intertight-black_28.png")
     )
-    
-    args = listOf(ttfFile.absolutePath, "28", "2048", "1200", "2", fontInfoDir.get().asFile.absolutePath, outDir.get().asFile.absolutePath, fontTexClasspath, "…–—•°™∞␡␈c←↑→↓⌃⇧⌥⌘□")
+
+    args = listOf(ttfFile.absolutePath, "28", "2048", "1200", "2", fontInfoDir.get().asFile.absolutePath, outDir.get().asFile.absolutePath, fontTexClasspath, extraGlyphCodepoints)
     onlyIf { ttfFile.exists() }
 }
 

--- a/tools/src/main/java/com/oddlabs/fontutil/FontRenderer.java
+++ b/tools/src/main/java/com/oddlabs/fontutil/FontRenderer.java
@@ -54,13 +54,10 @@ public final class FontRenderer {
                     "FontRenderer <font_name> <font_size> <max_image_width> <max_chars> <scale_factor> <font_info_dir> <font_tex_dir> <font_tex_classpath> <additional_codepoints_hex>");
         }
         try {
-            // additional_codepoints_hex is a comma-separated list of hex codepoints (ASCII only) so
-            // that glyphs outside the platform code page survive the command-line argv boundary.
-            IntStream additional = args[8].isEmpty()
-                    ? IntStream.empty()
-                    : Arrays.stream(args[8].split(",")).mapToInt(s -> Integer.parseInt(s.trim(), 16));
-            int[] codepoints = IntStream.concat(IntStream.range(0, Integer.parseInt(args[3])), additional)
-                    .toArray();
+            int baseCharCount = Integer.parseInt(args[3]);
+            IntStream baseCodepoints = IntStream.range(0, baseCharCount);
+            IntStream extraCodepoints = parseHexCodepoints(args[8]);
+            int[] codepoints = IntStream.concat(baseCodepoints, extraCodepoints).toArray();
 
             new FontRenderer(Path.of(args[0]),
                     Integer.parseInt(args[1]), Float.parseFloat(args[4]),
@@ -72,6 +69,21 @@ public final class FontRenderer {
             all.printStackTrace(System.err);
             System.exit(1);
         }
+    }
+
+    /**
+     * Parses a comma-separated list of hexadecimal Unicode codepoints (e.g. {@code "2026,221e"}).
+     * The codepoints are passed as ASCII hex rather than literal characters so glyphs outside the
+     * platform code page survive the command-line argv boundary (Windows {@code sun.jnu.encoding}
+     * is the legacy ANSI code page and would otherwise replace them with '?').
+     */
+    private static @NonNull IntStream parseHexCodepoints(@NonNull String csv) {
+        if (csv.isEmpty()) {
+            return IntStream.empty();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .mapToInt(hex -> Integer.parseInt(hex, 16));
     }
 
     public FontRenderer(@NonNull Path font_file,

--- a/tools/src/main/java/com/oddlabs/fontutil/FontRenderer.java
+++ b/tools/src/main/java/com/oddlabs/fontutil/FontRenderer.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.stream.IntStream;
 
 public final class FontRenderer {
@@ -50,10 +51,15 @@ public final class FontRenderer {
     static void main(@NonNull String @NonNull... args) {
         if (args.length < 9) {
             IO.println(
-                    "FontRenderer <font_name> <font_size> <max_image_width> <max_chars> <scale_factor> <font_info_dir> <font_tex_dir> <font_tex_classpath> <additional_chars>");
+                    "FontRenderer <font_name> <font_size> <max_image_width> <max_chars> <scale_factor> <font_info_dir> <font_tex_dir> <font_tex_classpath> <additional_codepoints_hex>");
         }
         try {
-            int[] codepoints = IntStream.concat(IntStream.range(0, Integer.parseInt(args[3])), args[8].codePoints())
+            // additional_codepoints_hex is a comma-separated list of hex codepoints (ASCII only) so
+            // that glyphs outside the platform code page survive the command-line argv boundary.
+            IntStream additional = args[8].isEmpty()
+                    ? IntStream.empty()
+                    : Arrays.stream(args[8].split(",")).mapToInt(s -> Integer.parseInt(s.trim(), 16));
+            int[] codepoints = IntStream.concat(IntStream.range(0, Integer.parseInt(args[3])), additional)
                     .toArray();
 
             new FontRenderer(Path.of(args[0]),


### PR DESCRIPTION
## Problem

Extra glyphs (`…–—•°™∞␡␈c←↑→↓⌃⇧⌥⌘□`) are passed to `FontRenderer` as literal characters on the command line. Command-line arguments are encoded through the JVM's `sun.jnu.encoding`, which on Windows is the legacy ANSI code page (e.g. `Cp1252`), not UTF-8 even on JDK 18+, since JEP 400 left `sun.jnu.encoding` as the platform encoding. It seems characters outside that code page (`∞ ← ⌘`, etc.) are silently replaced with `?` before `FontRenderer` runs, so they never get baked into the font atlas. Result: e.g. the `∞` build-spinner symbol renders fine on macOS (UTF-8) but is missing on Windows.

This was verified by probing the generated `intertight-black_28.font`: `• ° ™` (Cp1252-representable) present, `∞ ← ⌘` missing. `Font.canDisplay(0x221E)` is `true` for both TTFs, so the glyphs exist — only the transport was lossy. `-Dsun.jnu.encoding=UTF-8` does not fix it on Windows (the property can't be overridden there).

## Fix

Transport the glyph set as ASCII hex codepoints, which every code page encodes identically:

- `assets/build.gradle.kts`: keep the readable glyph string, but serialize it to comma-separated hex codepoints before passing to `FontRenderer`. Also declare the glyph set as a task input (`inputs.property("glyphs", ...)`) so changing it actually re-triggers font generation.
- `FontRenderer`: parse the final argument as comma-separated hex codepoints instead of literal characters.

Verified by regenerating the atlas on Windows: `∞ ← ⌘` are now present.